### PR TITLE
build: migrate GitHub Actions set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: 'Yarn: Get cache directory path'
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - name: 'Yarn: Restore dependencies from cache'
       uses: actions/cache@v3


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/